### PR TITLE
bug(news-title): top news title was duplicated on main screen

### DIFF
--- a/modern-news-app/src/components/TodayNews.tsx
+++ b/modern-news-app/src/components/TodayNews.tsx
@@ -32,7 +32,7 @@ const TodayNews: React.FC<MainProps> = ({ todayNewsData, enlargeArticle, setEnla
 
   return (
     <>
-      <MainPageTitle>Today News</MainPageTitle>
+      <MainPageTitle>Today's Top News</MainPageTitle>
         {todayNewsData.status ? (
           <ArticlesStyled>
           {todayNewsData.articles.map((article, i) => {

--- a/modern-news-app/src/components/TodayNews.tsx
+++ b/modern-news-app/src/components/TodayNews.tsx
@@ -31,7 +31,7 @@ const TodayNews: React.FC<MainProps> = ({ todayNewsData }) => {
 
   return (
     <>
-      <MainPageTitle>Top News</MainPageTitle>
+      <MainPageTitle>Today News</MainPageTitle>
         {todayNewsData.status ? (
           <ArticlesStyled>
           {todayNewsData.articles.map((article, i) => {


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Changes the second Top News title that was duplicated, to Today News.

## Purpose
Gives the section an accurate label.

_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #77 