### PR TITLE
bug(top-news): updates the top news section with time magazine.

### DIFF
--- a/modern-news-app/src/App.tsx
+++ b/modern-news-app/src/App.tsx
@@ -1,8 +1,7 @@
 // interface classes
 import { IEverythingNewsResponse, EverythingNewsRequest, EverythingNewsResponse } from './models/Articles';
-import { ITopNewsResponse } from './models/Articles';
-import { fetchNewsData } from './util/fetchApi';
-import { fetchTodayNewsData } from './util/fetchApi';
+import { TopNewsRequest, ITopNewsResponse, TopNewsResponse } from './models/TopNewsArticles';
+import { fetchNewsData, fetchTodayNewsData, fetchTopNewsData } from './util/fetchApi';
 import { BodyContainer } from "./style/Wrappers.style";
 import { ITodayNewsResponse, TodayNewsRequest, TodayNewsResponse } from './models/TodayArticles';
 
@@ -15,7 +14,7 @@ import { useEffect, useState } from 'react';
 
 const App = () => {
   const [newsData, setNewsData] = useState<IEverythingNewsResponse>(new EverythingNewsResponse())
-  const [topNewsData, setTopNewsData] = useState<ITopNewsResponse>(new EverythingNewsResponse())
+  const [topNewsData, setTopNewsData] = useState<ITopNewsResponse>(new TopNewsResponse())
   const [todayNewsData, setTodayNewsData] = useState<ITodayNewsResponse>(new TodayNewsResponse());
   const [enlargeArticle, setEnlargeArticle] = useState<string | null>(null)
 
@@ -38,9 +37,11 @@ const App = () => {
 
   const getTopNewsData = async (search: string) => {
     try {
-      const request = new EverythingNewsRequest({q: search});
-      const dataObject: ITopNewsResponse = await fetchNewsData(request);
+      const request = new TopNewsRequest({q: search, sources: "time"});
+      const dataObject: ITopNewsResponse = await fetchTopNewsData(request);
       setTopNewsData(dataObject);
+      console.log(dataObject)
+      return dataObject;
     } catch (error) {
       console.error(error)
     }

--- a/modern-news-app/src/App.tsx
+++ b/modern-news-app/src/App.tsx
@@ -40,8 +40,8 @@ const App = () => {
       const request = new TopNewsRequest({q: search, sources: "time"});
       const dataObject: ITopNewsResponse = await fetchTopNewsData(request);
       setTopNewsData(dataObject);
-      console.log(dataObject)
       return dataObject;
+      
     } catch (error) {
       console.error(error)
     }

--- a/modern-news-app/src/components/TopNews.tsx
+++ b/modern-news-app/src/components/TopNews.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { IEverythingNewsResponse } from "../models/Articles";
+import { ITopNewsResponse } from "../models/TopNewsArticles";
 import { MainPageTitle } from "../style/SectionTitles.style";
 import Article from "./Article";
 import ExpandedArticle from "./ExpandedArticle";
@@ -7,7 +7,7 @@ import { ArticlesStyled } from "./Main";
 
 
 interface TopNewsProps {
-  topNewsData: IEverythingNewsResponse;
+  topNewsData: ITopNewsResponse;
   enlargeArticle: string | null;
   setEnlargeArticle: Function;
 }

--- a/modern-news-app/src/models/TopNewsArticles.ts
+++ b/modern-news-app/src/models/TopNewsArticles.ts
@@ -1,35 +1,32 @@
-export interface IEverythingNewsRequest {
+export interface ITopNewsRequest {
     apiKey: string;
+    country: string;
+    category?: string;
+    sources: string;
     q: string;
     pageSize: number;
-    sortBy: SortBy;
-    qInTitle: string;
-    sources: string[];
-    domains: string[];
-    excludeDomains: string[];
-    from: string;
-    to: string;
-    language: string;
     page: number;
 }
 
 type SortBy = "relevancy" | "popularity" | "publishedAt";
 
-export class EverythingNewsRequest implements IEverythingNewsRequest {
+export class TopNewsRequest implements ITopNewsRequest {
     apiKey= process.env.REACT_APP_NEWS_API_KEY || "";
     q= "";
     pageSize= 4;
     sortBy= "popularity" as SortBy;
     qInTitle= "";
-    sources= [];
+    sources= "";
     domains= [];
     excludeDomains= [];
     from= "";
     to= "";
     language= "en";
     page= 1;
+    country= "us";
+    category= "health";
 
-    constructor(configOverride?: Partial<IEverythingNewsRequest>) {
+    constructor(configOverride?: Partial<ITopNewsRequest>) {
         if(configOverride) {
             Object.assign(this, configOverride);
             this.q = encodeURIComponent(this.q);
@@ -54,16 +51,16 @@ export interface IArticle {
     content: string;
 }
 
-export interface IEverythingNewsResponse {
+export interface ITopNewsResponse {
     status: string | null;
     totalResults: number;
     articles: IArticle[];
-    search?: string;
 }
 
-export class EverythingNewsResponse implements IEverythingNewsResponse{
-    status= null;
+export class TopNewsResponse implements ITopNewsResponse {
+    status = null;
     totalResults= 0;
     articles= [];
-    search= "";
-}
+ }
+ 
+ 

--- a/modern-news-app/src/util/fetchApi.ts
+++ b/modern-news-app/src/util/fetchApi.ts
@@ -1,10 +1,11 @@
 import { IEverythingNewsRequest } from "../models/Articles";
 import { ITodayNewsRequest } from "../models/TodayArticles";
+import { ITopNewsRequest } from "../models/TopNewsArticles";
 
 // return news data with a "q" search parameter
 export const fetchNewsData = async (request: IEverythingNewsRequest) => {
     try {
-        const baseUrl = `https://newsapi.org/v2/everything?q=${request.q}&pageSize=${request.pageSize}&apiKey=${request.apiKey}`;
+        const baseUrl = `https://newsapi.org/v2/everything?q=${request.q}&pageSize=${request.pageSize}&apiKey=${request.apiKey}&country=${request.sources}`;
         const newsResponse = await fetch(baseUrl).then(res => res.json());
         newsResponse.search = request.q
         return newsResponse
@@ -18,6 +19,18 @@ export const fetchTodayNewsData = async (request: ITodayNewsRequest) => {
         // url for US news with todays date
         const todayNewsUrl = `https://newsapi.org/v2/top-headlines?country=${request.sources}&apiKey=${request.apiKey}&pageSize=${request.pageSize}`;
         return await fetch(todayNewsUrl).then(res => res.json());
+
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+export const fetchTopNewsData = async (request: ITopNewsRequest) => {
+    try {
+        // url for Time Magazine news site
+        const topNewsUrl = `https://newsapi.org/v2/top-headlines?sources=${request.sources}&apiKey=${request.apiKey}&pageSize=${request.pageSize}`;
+        console.log(topNewsUrl)
+        return await fetch(topNewsUrl).then(res => res.json());
 
     } catch (error) {
         console.error(error);

--- a/modern-news-app/src/util/fetchApi.ts
+++ b/modern-news-app/src/util/fetchApi.ts
@@ -19,7 +19,6 @@ export const fetchTodayNewsData = async (request: ITodayNewsRequest) => {
         // url for US news with todays date
         const todayNewsUrl = `https://newsapi.org/v2/top-headlines?country=${request.sources}&apiKey=${request.apiKey}&pageSize=${request.pageSize}`;
         return await fetch(todayNewsUrl).then(res => res.json());
-
     } catch (error) {
         console.error(error);
     }
@@ -29,9 +28,7 @@ export const fetchTopNewsData = async (request: ITopNewsRequest) => {
     try {
         // url for Time Magazine news site
         const topNewsUrl = `https://newsapi.org/v2/top-headlines?sources=${request.sources}&apiKey=${request.apiKey}&pageSize=${request.pageSize}`;
-        console.log(topNewsUrl)
         return await fetch(topNewsUrl).then(res => res.json());
-
     } catch (error) {
         console.error(error);
     }


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Created a new function to fetch data for Top news section.
2. Fetches data for Time magazine and renders it on to top news section.
3. Created a new interface for Top news to pull in source of magazine from API.

## Purpose
This allows the top news section to be populated with different information than the today's top news section.

_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #74 